### PR TITLE
Expose functions to set versions and execution level

### DIFF
--- a/rcedit-sys/src/lib.rs
+++ b/rcedit-sys/src/lib.rs
@@ -12,6 +12,39 @@ extern "C" {
     pub fn ResourceUpdater_Commit(ctx: ResourceUpdater) -> bool;
 
     pub fn ResourceUpdater_SetIcon(ctx: ResourceUpdater, w_icon_path: *const u16) -> bool;
-    pub fn ResourceUpdater_ChangeRcdata(ctx: ResourceUpdater, id: u32, w_rcdata_path: *const u16) -> bool;
-    pub fn ResourceUpdater_ChangeString(ctx: ResourceUpdater, id: u32, w_rcdata_path: *const u16) -> bool;
+
+    pub fn ResourceUpdater_SetVersionString(
+        ctx: ResourceUpdater,
+        w_name: *const u16,
+        w_value: *const u16,
+    ) -> bool;
+
+    pub fn ResourceUpdater_SetProductVersion(
+        ctx: ResourceUpdater,
+        v1: u16,
+        v2: u16,
+        v3: u16,
+        v4: u16,
+    ) -> bool;
+
+    pub fn ResourceUpdater_SetFileVersion(
+        ctx: ResourceUpdater,
+        v1: u16,
+        v2: u16,
+        v3: u16,
+        v4: u16,
+    ) -> bool;
+
+    pub fn ResourceUpdater_SetExecutionLevel(ctx: ResourceUpdater, wLevel: *const u16) -> bool;
+
+    pub fn ResourceUpdater_ChangeRcdata(
+        ctx: ResourceUpdater,
+        id: u32,
+        w_rcdata_path: *const u16,
+    ) -> bool;
+    pub fn ResourceUpdater_ChangeString(
+        ctx: ResourceUpdater,
+        id: u32,
+        w_rcdata_path: *const u16,
+    ) -> bool;
 }

--- a/rcedit-sys/src/librcedit.cpp
+++ b/rcedit-sys/src/librcedit.cpp
@@ -35,6 +35,30 @@ extern "C"
         return resourceUpdater->SetIcon(wIconPath);
     }
 
+    bool ResourceUpdater_SetVersionString(ResourceUpdater* ctx, const wchar_t* wName, const wchar_t* wValue)
+    {
+        auto resourceUpdater = reinterpret_cast<rescle::ResourceUpdater*>(ctx);
+        return resourceUpdater->SetVersionString(wName, wValue);
+    }
+
+    bool ResourceUpdater_SetProductVersion(ResourceUpdater* ctx, unsigned short v1, unsigned short v2, unsigned short v3, unsigned short v4)
+    {
+        auto resourceUpdater = reinterpret_cast<rescle::ResourceUpdater*>(ctx);
+        return resourceUpdater->SetProductVersion(v1, v2, v3, v4);
+    }
+
+    bool ResourceUpdater_SetFileVersion(ResourceUpdater* ctx, unsigned short v1, unsigned short v2, unsigned short v3, unsigned short v4)
+    {
+        auto resourceUpdater = reinterpret_cast<rescle::ResourceUpdater*>(ctx);
+        return resourceUpdater->SetFileVersion(v1, v2, v3, v4);
+    }
+
+    bool ResourceUpdater_SetExecutionLevel(ResourceUpdater* ctx, const wchar_t* wLevel)
+    {
+        auto resourceUpdater = reinterpret_cast<rescle::ResourceUpdater*>(ctx);
+        return resourceUpdater->SetExecutionLevel(wLevel);
+    }    
+
     bool ResourceUpdater_ChangeRcdata(ResourceUpdater* ctx, uint32_t id, const wchar_t* wRcdataPath)
     {
         auto resourceUpdater = reinterpret_cast<rescle::ResourceUpdater*>(ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,47 @@ impl ResourceUpdater {
         }
     }
 
+    pub fn set_version_string(&mut self, name: &str, value: &str) -> RceditResult<()> {
+        let cstr_name = utf8_to_wide_string(name)?;
+        let cstr_value = utf8_to_wide_string(value)?;
+        if unsafe {
+            sys::ResourceUpdater_SetVersionString(
+                self.handle,
+                cstr_name.as_ptr(),
+                cstr_value.as_ptr(),
+            )
+        } {
+            Ok(())
+        } else {
+            Err(RceditError::ResourceUpdateFailure)
+        }
+    }
+
+    pub fn set_file_version(&mut self, v1: u16, v2: u16, v3: u16, v4: u16) -> RceditResult<()> {
+        if unsafe { sys::ResourceUpdater_SetFileVersion(self.handle, v1, v2, v3, v4) } {
+            Ok(())
+        } else {
+            Err(RceditError::ResourceUpdateFailure)
+        }
+    }
+
+    pub fn set_product_version(&mut self, v1: u16, v2: u16, v3: u16, v4: u16) -> RceditResult<()> {
+        if unsafe { sys::ResourceUpdater_SetProductVersion(self.handle, v1, v2, v3, v4) } {
+            Ok(())
+        } else {
+            Err(RceditError::ResourceUpdateFailure)
+        }
+    }
+
+    pub fn set_execution_level(&mut self, level: &str) -> RceditResult<()> {
+        let cstr = utf8_to_wide_string(level)?;
+        if unsafe { sys::ResourceUpdater_SetExecutionLevel(self.handle, cstr.as_ptr()) } {
+            Ok(())
+        } else {
+            Err(RceditError::ResourceUpdateFailure)
+        }
+    }
+
     pub fn set_string(&mut self, string_id: u32, data: &str) -> RceditResult<()> {
         let cstr = utf8_to_wide_string(data)?;
         if unsafe { sys::ResourceUpdater_ChangeString(self.handle, string_id, cstr.as_ptr()) } {


### PR DESCRIPTION
This PR exposes a few more functions to edit version strings, version numbers and execution level.

It looks like many of these properties on executables are accessible via Powershell. Would you be open to another PR that extends the tests and ensures that they're actually being set and tests all this in GitHub actions?